### PR TITLE
Support for registering all handlers from assembly by assembly name

### DIFF
--- a/Rebus.ServiceProvider/ServiceCollectionExtensions.cs
+++ b/Rebus.ServiceProvider/ServiceCollectionExtensions.cs
@@ -42,7 +42,9 @@ namespace Rebus.ServiceProvider
             if (string.IsNullOrEmpty(assemblyString))
                 throw new ArgumentNullException(nameof(assemblyString));
 
-            var assembly = Assembly.Load(assemblyString);
+            var assemblyName = new AssemblyName(assemblyString);
+
+            var assembly = Assembly.Load(assemblyName);
 
             RegisterAssembly(services, assembly);
         }

--- a/Rebus.ServiceProvider/ServiceCollectionExtensions.cs
+++ b/Rebus.ServiceProvider/ServiceCollectionExtensions.cs
@@ -28,6 +28,24 @@ namespace Rebus.ServiceProvider
 
             RegisterAssembly(services, assemblyToRegister);
         }
+        
+        /// <summary>
+        /// Automatically picks up all handler types from the specified assembly and registers them in the container
+        /// </summary>
+        /// <param name="services">The services</param>
+        /// <param name="assemblyString">The long name of the assembly</param>
+        public static void AutoRegisterHandlersFromAssembly(this IServiceCollection services, string assemblyString)
+        {
+            if (services == null)
+                throw new ArgumentNullException(nameof(services));
+
+            if (string.IsNullOrEmpty(assemblyString))
+                throw new ArgumentNullException(nameof(assemblyString));
+
+            var assembly = Assembly.Load(assemblyString);
+
+            RegisterAssembly(services, assembly);
+        }
 
         static Assembly GetAssembly<THandler>() where THandler : IHandleMessages
         {


### PR DESCRIPTION
Added a new extension to register all handlers from an assembly by specifying an assembly long name. Useful for registering handlers from XML/JSON config, where you can't use the generic method (AutoRegisterHandlersFromAssemblyOf) for registering assemblies.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
