### PR TITLE
Feature/use rebus with action

### DIFF
--- a/Rebus.ServiceProvider.sln
+++ b/Rebus.ServiceProvider.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.12
+VisualStudioVersion = 15.0.26430.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "stuff", "stuff", "{1ABDD7C1-1F8D-402D-8692-3E4B66962DE0}"
 	ProjectSection(SolutionItems) = preProject
@@ -14,9 +14,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rebus.ServiceProvider", "Re
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rebus.ServiceProvider.Tests", "Rebus.ServiceProvider.Tests\Rebus.ServiceProvider.Tests.csproj", "{9A24DD7A-7C30-49B6-B949-BF8F360E9F51}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.ConsoleApp", "Sample.ConsoleApp\Sample.ConsoleApp.csproj", "{EBDD4021-4E2C-4695-9208-1A9405DAC8C0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.ConsoleApp", "Sample.ConsoleApp\Sample.ConsoleApp.csproj", "{EBDD4021-4E2C-4695-9208-1A9405DAC8C0}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{4C1C1464-DCA0-4215-8A7D-30AC85E6D995}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.WebApp", "Sample.WebApp\Sample.WebApp.csproj", "{5FFF4903-E277-4E15-96C5-9FFBE7BB8AB2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -36,11 +38,16 @@ Global
 		{EBDD4021-4E2C-4695-9208-1A9405DAC8C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EBDD4021-4E2C-4695-9208-1A9405DAC8C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EBDD4021-4E2C-4695-9208-1A9405DAC8C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5FFF4903-E277-4E15-96C5-9FFBE7BB8AB2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5FFF4903-E277-4E15-96C5-9FFBE7BB8AB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5FFF4903-E277-4E15-96C5-9FFBE7BB8AB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5FFF4903-E277-4E15-96C5-9FFBE7BB8AB2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{EBDD4021-4E2C-4695-9208-1A9405DAC8C0} = {4C1C1464-DCA0-4215-8A7D-30AC85E6D995}
+		{5FFF4903-E277-4E15-96C5-9FFBE7BB8AB2} = {4C1C1464-DCA0-4215-8A7D-30AC85E6D995}
 	EndGlobalSection
 EndGlobal

--- a/Rebus.ServiceProvider/ApplicationBuilderExtensions.cs
+++ b/Rebus.ServiceProvider/ApplicationBuilderExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Rebus.Bus;
+using Rebus.ServiceProvider;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Defines common operations for Rebus when using an <see cref="IApplicationBuilder"/>.
+    /// </summary>
+    public static class ApplicationBuilderExtensions
+    {
+        /// <summary>
+        /// Activates the Rebus engine, allowing it to start sending and receiving messages.
+        /// </summary>
+        /// <param name="app">The application hosting Rebus.</param>
+        public static IApplicationBuilder UseRebus(this IApplicationBuilder app)
+        {
+            app.ApplicationServices.UseRebus();
+            return app;
+        }
+
+        /// <summary>
+        /// Activates the Rebus engine, allowing it to start sending and receiving messages.
+        /// </summary>
+        /// <param name="app">The application hosting Rebus.</param>
+        /// <param name="busAction">An action to perform on the bus.</param>
+        public static IApplicationBuilder UseRebus(this IApplicationBuilder app, Action<IBus> busAction)
+        {
+            app.ApplicationServices.UseRebus(busAction);
+            return app;
+        }
+    }
+}

--- a/Rebus.ServiceProvider/ServiceProviderExtensions.cs
+++ b/Rebus.ServiceProvider/ServiceProviderExtensions.cs
@@ -18,5 +18,16 @@ namespace Rebus.ServiceProvider
             provider.GetRequiredService<IBus>();
             return provider;
         }
+
+        /// <summary>
+        /// Activates the Rebus engine, allowing it to start sending and receiving messages.
+        /// </summary>
+        /// <param name="provider">The service provider configured for Rebus.</param>
+        /// <param name="busAction">An action to perform on the bus.</param>
+        public static IServiceProvider UseRebus(this IServiceProvider provider, Action<IBus> busAction)
+        {
+            busAction(provider.GetRequiredService<IBus>());
+            return provider;
+        }
     }
 }

--- a/Sample.WebApp/Handler1.cs
+++ b/Sample.WebApp/Handler1.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Rebus.Handlers;
+
+namespace Sample.WebApp
+{
+    public class Handler1 : IHandleMessages<Message1>
+    {
+        private readonly ILogger _logger;
+
+        public Handler1(ILogger<Handler1> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task Handle(Message1 message)
+        {
+            _logger.LogInformation("Handler1 received : {message}", message);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Sample.WebApp/MSLoggerFactoryAdapter.cs
+++ b/Sample.WebApp/MSLoggerFactoryAdapter.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Rebus.Logging;
+
+namespace Sample.WebApp
+{
+    public class MSLoggerFactoryAdapter : AbstractRebusLoggerFactory
+    {
+        private readonly ILoggerFactory _logger;
+
+        public MSLoggerFactoryAdapter(ILoggerFactory logger)
+        {
+            _logger = logger;
+        }
+
+        protected override ILog GetLogger(Type type)
+        {
+            return new MSLoggerAdapter(_logger.CreateLogger(type));
+        }
+    }
+
+    public class MSLoggerAdapter : ILog
+    {
+        private readonly ILogger _logger;
+
+        public MSLoggerAdapter(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public void Debug(string message, params object[] objs)
+        {
+            _logger.LogDebug(message, objs);
+        }
+
+        public void Info(string message, params object[] objs)
+        {
+            _logger.LogInformation(message, objs);
+        }
+
+        public void Warn(string message, params object[] objs)
+        {
+            _logger.LogWarning(message, objs);
+        }
+
+        public void Warn(Exception exception, string message, params object[] objs)
+        {
+            _logger.LogWarning(message, objs, exception);
+        }
+
+        public void Error(Exception exception, string message, params object[] objs)
+        {
+            _logger.LogError(message, objs, exception);
+        }
+
+        public void Error(string message, params object[] objs)
+        {
+            _logger.LogError(message, objs);
+        }
+    }
+}

--- a/Sample.WebApp/Message1.cs
+++ b/Sample.WebApp/Message1.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Sample.WebApp
+{
+    public class Message1
+    {
+        public Message1()
+        {
+            Id = Guid.NewGuid();
+        }
+
+        public Guid Id { get; }
+
+        public override string ToString()
+        {
+            return $"Message1 : {Id}";
+        }
+    }
+}

--- a/Sample.WebApp/Program.cs
+++ b/Sample.WebApp/Program.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Sample.WebApp
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseIISIntegration()
+                .CaptureStartupErrors(true)
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/Sample.WebApp/Properties/launchSettings.json
+++ b/Sample.WebApp/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:60043/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Sample.WebApp": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:59868"
+    }
+  }
+}

--- a/Sample.WebApp/Sample.WebApp.csproj
+++ b/Sample.WebApp/Sample.WebApp.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Rebus.ServiceProvider\Rebus.ServiceProvider.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Sample.WebApp/Startup.cs
+++ b/Sample.WebApp/Startup.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Rebus.Bus;
+using Rebus.Routing.TypeBased;
+using Rebus.ServiceProvider;
+using Rebus.Transport.InMem;
+
+namespace Sample.WebApp
+{
+    public class Startup
+    {
+        private readonly ILoggerFactory _loggerFactory;
+
+        public Startup(ILoggerFactory loggerFactory)
+        {
+            _loggerFactory = loggerFactory;
+            _loggerFactory.AddDebug(); // logs to the debug output window in VS.
+        }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Register handlers 
+            services.AutoRegisterHandlersFromAssemblyOf<Handler1>();
+
+            // Configure and register Rebus
+            services.AddRebus(configure => configure
+                .Logging(l => l.Use(new MSLoggerFactoryAdapter(_loggerFactory)))
+                .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "Messages"))
+                .Routing(r => r.TypeBased().MapAssemblyOf<Message1>("Messages")));
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        {
+            app
+                .UseDeveloperExceptionPage()
+                .UseRebus()
+                .Run(async (context) =>
+                {
+                    var bus = app.ApplicationServices.GetRequiredService<IBus>();
+                    var logger = app.ApplicationServices.GetRequiredService<ILogger<Startup>>();
+
+                    logger.LogInformation("Publishing {MessageCount} messages", 10);
+
+                    await Task.WhenAll(
+                        Enumerable.Range(0, 10)
+                            .Select(i => new Message1())
+                            .Select(message => bus.Send(message)));
+
+                    await context.Response.WriteAsync("Rebus sent another 10 messages!");
+                });
+        }
+    }
+}


### PR DESCRIPTION
To address this issue: https://github.com/rebus-org/Rebus.ServiceProvider/issues/6

Plus added a sample web app to show how Rebus gets setup in a Startup.cs.

It actually highlighted the need for a logging bridge between Rebus and MS' new Logging component.  It's very simple - see MSLoggerFactoryAdapter.cs in Sample.WebApp.  Could be worth providing in it's own package?

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
