### PR TITLE
Pass provider to configuration action

### DIFF
--- a/Rebus.ServiceProvider/ServiceCollectionExtensions.Bus.cs
+++ b/Rebus.ServiceProvider/ServiceCollectionExtensions.Bus.cs
@@ -16,6 +16,17 @@ namespace Rebus.ServiceProvider
         /// <param name="configureRebus">The optional configuration actions for Rebus.</param>
         public static IServiceCollection AddRebus(this IServiceCollection services, Func<RebusConfigurer, RebusConfigurer> configureRebus)
         {
+            return AddRebus(services, (c, p) => configureRebus(c));
+        }
+
+
+        /// <summary>
+        /// Registers and/or modifies Rebus configuration for the current service collection.
+        /// </summary>
+        /// <param name="services">The current message service builder.</param>
+        /// <param name="configureRebus">The optional configuration actions for Rebus.</param>
+        public static IServiceCollection AddRebus(this IServiceCollection services, Func<RebusConfigurer, IServiceProvider, RebusConfigurer> configureRebus)
+        {
             if (configureRebus == null)
             {
                 throw new ArgumentNullException(nameof(configureRebus));
@@ -36,7 +47,7 @@ namespace Rebus.ServiceProvider
             services.AddSingleton(provider =>
             {
                 var configurer = Configure.With(provider.GetRequiredService<NetCoreServiceProviderContainerAdapter>());
-                configureRebus(configurer);
+                configureRebus(configurer, provider);
 
                 return configurer.Start();
             });


### PR DESCRIPTION
Add the facility to pass the provider to the configuration action, to allow resolving dependencies as arguments in the configuration.

For example, when configuring Subscription storage I may want to use a database already configured in the container:

`.Subscriptions(c => c.StoreInMongoDb(p.GetService<IMongoDatabase>(),"TableName")`

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
