### PR TITLE
Fix problems with tests

### DIFF
--- a/Rebus.ServiceProvider.Tests/NetCoreServiceProviderActivationContext.cs
+++ b/Rebus.ServiceProvider.Tests/NetCoreServiceProviderActivationContext.cs
@@ -15,14 +15,14 @@ namespace Rebus.ServiceProvider.Tests
     {
         public IHandlerActivator CreateActivator(Action<IHandlerRegistry> handlerConfig, out IActivatedContainer container)
         {
-            var services = new ServiceCollection().AddSingleton(p => new NetCoreServiceProviderContainerAdapter(p));
+            var services = new ServiceCollection().AddSingleton(p => new DependencyInjectionHandlerActivator(p));
             handlerConfig.Invoke(new HandlerRegistry(services));
             
             var provider = services.BuildServiceProvider();
 
             container = new ActivatedContainer(provider);
 
-            return provider.GetRequiredService<NetCoreServiceProviderContainerAdapter>();
+            return provider.GetRequiredService<DependencyInjectionHandlerActivator>();
         }
 
         public IBus CreateBus(Action<IHandlerRegistry> handlerConfig, Func<RebusConfigurer, RebusConfigurer> configureBus, out IActivatedContainer container)

--- a/Rebus.ServiceProvider.Tests/NetCoreServiceProviderActivationContext.cs
+++ b/Rebus.ServiceProvider.Tests/NetCoreServiceProviderActivationContext.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Rebus.Activation;
 using Rebus.Bus;
 using Rebus.Config;
@@ -17,24 +15,20 @@ namespace Rebus.ServiceProvider.Tests
     {
         public IHandlerActivator CreateActivator(Action<IHandlerRegistry> handlerConfig, out IActivatedContainer container)
         {
-            var services = new ServiceCollection();
+            var services = new ServiceCollection().AddSingleton(p => new NetCoreServiceProviderContainerAdapter(p));
             handlerConfig.Invoke(new HandlerRegistry(services));
-            services.AddSingleton<IApplicationLifetime>(new TestLifetime());
-
-            var provider = services.BuildServiceProvider();
             
-            var adapter = new NetCoreServiceProviderContainerAdapter(provider);
+            var provider = services.BuildServiceProvider();
 
             container = new ActivatedContainer(provider);
 
-            return adapter;
+            return provider.GetRequiredService<NetCoreServiceProviderContainerAdapter>();
         }
 
         public IBus CreateBus(Action<IHandlerRegistry> handlerConfig, Func<RebusConfigurer, RebusConfigurer> configureBus, out IActivatedContainer container)
         {
             var services = new ServiceCollection();
             handlerConfig.Invoke(new HandlerRegistry(services));
-            services.AddSingleton<IApplicationLifetime>(new TestLifetime());
 
             services.AddRebus(configureBus);
 
@@ -73,9 +67,9 @@ namespace Rebus.ServiceProvider.Tests
 
         class ActivatedContainer : IActivatedContainer
         {
-            readonly IServiceProvider _provider;
+            readonly Microsoft.Extensions.DependencyInjection.ServiceProvider _provider;
 
-            public ActivatedContainer(IServiceProvider provider)
+            public ActivatedContainer(Microsoft.Extensions.DependencyInjection.ServiceProvider provider)
             {
                 _provider = provider;
             }
@@ -87,45 +81,7 @@ namespace Rebus.ServiceProvider.Tests
 
             public void Dispose()
             {
-                _provider.GetRequiredService<IApplicationLifetime>().StopApplication();
-            }
-        }
-
-        class TestLifetime : IApplicationLifetime
-        {
-            readonly CancellationTokenSource _stoppingSource;
-            readonly CancellationTokenSource _stoppedSource;
-
-            public TestLifetime()
-            {
-                var source = new CancellationTokenSource();
-                ApplicationStarted = source.Token;
-                source.Cancel();
-
-                _stoppingSource = new CancellationTokenSource();
-                _stoppedSource = new CancellationTokenSource();
-
-                ApplicationStopping = _stoppingSource.Token;
-                ApplicationStopped = _stoppedSource.Token;
-            }
-
-            public CancellationToken ApplicationStarted { get; }
-
-            public CancellationToken ApplicationStopping { get; }
-
-            public CancellationToken ApplicationStopped { get; }
-
-            public void StopApplication()
-            {
-                _stoppingSource.Cancel();
-
-                var allHandlersStopped = new CancellationTokenSource();
-                _stoppedSource.Token.Register(() => allHandlersStopped.Cancel());
-
-                _stoppedSource.Cancel();
-
-                // make sure we block untill all the handlers have finished.
-                allHandlersStopped.Token.WaitHandle.WaitOne();
+               _provider.Dispose();
             }
         }
     }

--- a/Rebus.ServiceProvider.Tests/Rebus.ServiceProvider.Tests.csproj
+++ b/Rebus.ServiceProvider.Tests/Rebus.ServiceProvider.Tests.csproj
@@ -28,7 +28,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Rebus.ServiceProvider\Rebus.ServiceProvider.csproj" />
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />

--- a/Rebus.ServiceProvider/DependencyInjectionHandlerActivator.cs
+++ b/Rebus.ServiceProvider/DependencyInjectionHandlerActivator.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Rebus.Activation;
-using Rebus.Bus;
 using Rebus.Extensions;
 using Rebus.Handlers;
 using Rebus.Transport;
@@ -13,20 +12,18 @@ using Rebus.Transport;
 namespace Rebus.ServiceProvider
 {
     /// <summary>
-    /// Implementation of <see cref="IContainerAdapter"/> that is backed by a ServiceProvider
+    /// Implementation of <see cref="IHandlerActivator"/> that is backed by a ServiceProvider
     /// </summary>
-    /// <seealso cref="IContainerAdapter" />
-    public class NetCoreServiceProviderContainerAdapter : IContainerAdapter, IDisposable
+    /// <seealso cref="IHandlerActivator" />
+    public class DependencyInjectionHandlerActivator : IHandlerActivator
     {
         readonly IServiceProvider _provider;
 
-        IBus _bus;
-
         /// <summary>
-        /// Initializes a new instance of the <see cref="NetCoreServiceProviderContainerAdapter"/> class.
+        /// Initializes a new instance of the <see cref="DependencyInjectionHandlerActivator"/> class.
         /// </summary>
         /// <param name="provider">The service provider used to yield handler instances.</param>
-        public NetCoreServiceProviderContainerAdapter(IServiceProvider provider)
+        public DependencyInjectionHandlerActivator(IServiceProvider provider)
         {
             _provider = provider ?? throw new ArgumentNullException(nameof(provider));
         }
@@ -45,22 +42,7 @@ namespace Rebus.ServiceProvider
 
             return Task.FromResult((IEnumerable<IHandleMessages<TMessage>>)resolvedHandlerInstances.ToArray());
         }
-
-        /// <summary>
-        /// Sets the bus instance associated with this <see cref="T:Rebus.Activation.IContainerAdapter" />.
-        /// </summary>
-        /// <param name="bus"></param>
-        /// <exception cref="ArgumentNullException"></exception>
-        public void SetBus(IBus bus)
-        {
-            if (_bus != null)
-            {
-                throw new InvalidOperationException("Cannot set the bus instance more than once on the container adapter.");
-            }
-
-            _bus = bus ?? throw new ArgumentNullException(nameof(bus));
-        }
-
+        
         List<IHandleMessages<TMessage>> GetMessageHandlersForMessage<TMessage>(IServiceScope scope)
         {
             var handledMessageTypes = typeof(TMessage).GetBaseTypes()
@@ -75,32 +57,6 @@ namespace Rebus.ServiceProvider
                 })
                 .Cast<IHandleMessages<TMessage>>()
                 .ToList();
-        }
-
-        bool _disposed;
-
-        /// <summary>
-        /// Disposes of the bus.
-        /// </summary>
-        /// <param name="disposing"></param>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (_disposed) return;
-
-            if (disposing)
-            {
-                _bus?.Dispose();
-            }
-
-            _disposed = true;
-        }
-
-        /// <summary>
-        /// Disposes of the bus.
-        /// </summary>
-        public void Dispose()
-        {
-            Dispose(true);
         }
     }
 }

--- a/Rebus.ServiceProvider/NetCoreServiceProviderContainerAdapter.cs
+++ b/Rebus.ServiceProvider/NetCoreServiceProviderContainerAdapter.cs
@@ -16,7 +16,7 @@ namespace Rebus.ServiceProvider
     /// Implementation of <see cref="IContainerAdapter"/> that is backed by a ServiceProvider
     /// </summary>
     /// <seealso cref="IContainerAdapter" />
-    public class NetCoreServiceProviderContainerAdapter : IContainerAdapter
+    public class NetCoreServiceProviderContainerAdapter : IContainerAdapter, IDisposable
     {
         readonly IServiceProvider _provider;
 

--- a/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
+++ b/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
@@ -43,7 +43,6 @@
     <None Include="ServiceCollectionExtensions.Bus.cs" />
   </ItemGroup>
   <ItemGroup>
-    
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Rebus" Version="5.2.1" />
   </ItemGroup>

--- a/Rebus.ServiceProvider/ServiceCollectionExtensions.Bus.cs
+++ b/Rebus.ServiceProvider/ServiceCollectionExtensions.Bus.cs
@@ -43,10 +43,10 @@ namespace Rebus.ServiceProvider
             services.AddTransient(s => s.GetService<IBus>().Advanced.SyncBus);
 
             // Register the Rebus Bus instance, to be created when it is first requested.
-            services.AddSingleton(provider => new NetCoreServiceProviderContainerAdapter(provider));
+            services.AddSingleton(provider => new DependencyInjectionHandlerActivator(provider));
             services.AddSingleton(provider =>
             {
-                var configurer = Configure.With(provider.GetRequiredService<NetCoreServiceProviderContainerAdapter>());
+                var configurer = Configure.With(provider.GetRequiredService<DependencyInjectionHandlerActivator>());
                 configureRebus(configurer, provider);
 
                 return configurer.Start();


### PR DESCRIPTION
That was a nice stack of compounding problems.

Changing the tests to dispose of the provider fixed the RealContainer test and matched the behaviour I was seeing in the samples (IBus was being disposed as expected), but the ContainerTests still failed due to the SetBus call. I initially just added the adapter to the container + used IDisposable, but realized that IContainerAdapter isn't needed at all (since M.E.D handles the IBus lifetime) and can be safely removed.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
