### PR TITLE
Bumped version of Microsoft.Extensions.DepdendencyInjection from 2.1.…

### DIFF
--- a/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
+++ b/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
@@ -43,7 +43,7 @@
     <None Include="ServiceCollectionExtensions.Bus.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Rebus" Version="5.2.1" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">


### PR DESCRIPTION
…1 -> 2.2.0

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
