### PR TITLE
Update to Rebus 6.0.0

### DIFF
--- a/Rebus.ServiceProvider.Tests/NetCoreServiceProviderActivationContext.cs
+++ b/Rebus.ServiceProvider.Tests/NetCoreServiceProviderActivationContext.cs
@@ -51,8 +51,10 @@ namespace Rebus.ServiceProvider.Tests
 
             public IHandlerRegistry Register<THandler>() where THandler : class, IHandleMessages
             {
-                GetHandlerInterfaces(typeof(THandler))
-                    .ForEach(i => _services.AddTransient(i, typeof(THandler)));
+                foreach (var handlerInterface in GetHandlerInterfaces(typeof(THandler)))
+                {
+                    _services.AddTransient(handlerInterface, typeof(THandler));
+                }
 
                 return this;
             }

--- a/Rebus.ServiceProvider.Tests/Rebus.ServiceProvider.Tests.csproj
+++ b/Rebus.ServiceProvider.Tests/Rebus.ServiceProvider.Tests.csproj
@@ -29,10 +29,10 @@
     <ProjectReference Include="..\Rebus.ServiceProvider\Rebus.ServiceProvider.csproj" />
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="nunit" Version="3.11.0" />
+    <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
-    <PackageReference Include="Rebus" Version="5.2.1" />
-    <PackageReference Include="Rebus.Tests.Contracts" Version="5.0.0" />
+    <PackageReference Include="Rebus" Version="6.0.0" />
+    <PackageReference Include="Rebus.Tests.Contracts" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Rebus.ServiceProvider/DependencyInjectionHandlerActivator.cs
+++ b/Rebus.ServiceProvider/DependencyInjectionHandlerActivator.cs
@@ -38,7 +38,7 @@ namespace Rebus.ServiceProvider
             {
                 var scope = GetOrCreateScope(transactionContext);
 
-                transactionContext.OnDisposed(scope.Dispose);
+                transactionContext.OnDisposed(ctx => scope.Dispose());
 
                 var resolvedHandlerInstances = GetMessageHandlersForMessage<TMessage>(scope);
 

--- a/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
+++ b/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Include="Rebus" Version="5.2.1" />
+    <PackageReference Include="Rebus" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.Hosting.Abstractions">

--- a/Rebus.ServiceProvider/ServiceCollectionExtensions.Bus.cs
+++ b/Rebus.ServiceProvider/ServiceCollectionExtensions.Bus.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Rebus.Bus;
 using Rebus.Config;
 using Rebus.Pipeline;
-using Rebus.Startup;
 
 namespace Rebus.ServiceProvider
 {

--- a/Rebus.ServiceProvider/ServiceProviderExtensions.cs
+++ b/Rebus.ServiceProvider/ServiceProviderExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
 using Rebus.Bus;
-using Rebus.Startup;
+using Rebus.Config;
 
 // ReSharper disable UnusedMember.Global
 

--- a/Sample.ConsoleApp/Sample.ConsoleApp.csproj
+++ b/Sample.ConsoleApp/Sample.ConsoleApp.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rebus" Version="5.2.1" />
+    <PackageReference Include="Rebus" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated Rebus from v5 to v6.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
