### PR TITLE
change activator injection to allow outside dependency replacement

### DIFF
--- a/Rebus.ServiceProvider.Tests/RemoveDuplicateHandlers.cs
+++ b/Rebus.ServiceProvider.Tests/RemoveDuplicateHandlers.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
+using Rebus.Activation;
 using Rebus.Handlers;
 using Rebus.Routing.TypeBased;
 using Rebus.Transport;
@@ -32,7 +33,7 @@ namespace Rebus.ServiceProvider.Tests
                 .BuildServiceProvider()
                 .UseRebus();
 
-            var activator = provider.GetRequiredService<DependencyInjectionHandlerActivator>();
+            var activator = provider.GetRequiredService<IHandlerActivator>();
 
             // Assert
             using (var scope = new RebusTransactionScope())

--- a/Rebus.ServiceProvider/Config/ServiceCollectionExtensions.Bus.cs
+++ b/Rebus.ServiceProvider/Config/ServiceCollectionExtensions.Bus.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Rebus.Activation;
 using Rebus.Bus;
 using Rebus.Config;
 using Rebus.Pipeline;
@@ -48,17 +49,18 @@ It is advised to use one container instance per bus instance, because this way i
             BusLifetimeEvents busLifetimeEvents = null;
 
             // Register the Rebus Bus instance, to be created when it is first requested.
-            services.AddSingleton(provider => new DependencyInjectionHandlerActivator(provider));
+            services.AddSingleton<IHandlerActivator, DependencyInjectionHandlerActivator>();
+
             services.AddSingleton(provider =>
             {
-                var activator = provider.GetRequiredService<DependencyInjectionHandlerActivator>();
+                var activator = provider.GetRequiredService<IHandlerActivator>();
 
                 var configurer = Configure.With(activator);
 
                 configure(configurer, provider);
 
                 var starter = configurer
-                    
+
                     // little hack: we snatch the lifetime events here...
                     .Options(o => o.Decorate(c => busLifetimeEvents = c.Get<BusLifetimeEvents>()))
 
@@ -81,7 +83,7 @@ It is advised to use one container instance per bus instance, because this way i
             {
                 // first, ensure that the busLifetimeEventsInstance has been set
                 provider.GetRequiredService<IBus>();
-               
+
                 // then return the instance
                 return busLifetimeEvents;
             });


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.


This PR is to allow the activator injection replacement by implementing custom IHandlerActivator interface.