### PR TITLE
Add overload for registering a handler type directly on the service collection

### DIFF
--- a/Rebus.ServiceProvider/Config/ServiceCollectionExtensions.Handlers.cs
+++ b/Rebus.ServiceProvider/Config/ServiceCollectionExtensions.Handlers.cs
@@ -18,9 +18,18 @@ namespace Rebus.ServiceProvider
         /// </summary>
         public static IServiceCollection AddRebusHandler<THandler>(this IServiceCollection services) where THandler : IHandleMessages
         {
-            if (services == null) throw new ArgumentNullException(nameof(services));
+            return AddRebusHandler(services, typeof(THandler));
+        }
 
-            RegisterType(services, typeof(THandler));
+        /// <summary>
+        /// Register the given <paramref name="typeToRegister"/> with a transient lifestyle
+        /// </summary>
+        public static IServiceCollection AddRebusHandler(this IServiceCollection services, Type typeToRegister)
+        {
+            if (services == null) throw new ArgumentNullException(nameof(services));
+            if(typeToRegister == null) throw new ArgumentNullException(nameof(typeToRegister));
+
+            RegisterType(services, typeToRegister);
 
             return services;
         }


### PR DESCRIPTION
As discussed. 

Closes #42


---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
