### PR TITLE
Register DependencyInjectionHandlerActivator as IHandlerActivator

### DIFF
--- a/Rebus.ServiceProvider.Tests/RemoveDuplicateHandlers.cs
+++ b/Rebus.ServiceProvider.Tests/RemoveDuplicateHandlers.cs
@@ -6,6 +6,7 @@ using Rebus.Routing.TypeBased;
 using Rebus.Transport;
 using Rebus.Transport.InMem;
 using System.Threading.Tasks;
+using Rebus.Activation;
 
 namespace Rebus.ServiceProvider.Tests
 {
@@ -32,7 +33,7 @@ namespace Rebus.ServiceProvider.Tests
                 .BuildServiceProvider()
                 .UseRebus();
 
-            var activator = provider.GetRequiredService<DependencyInjectionHandlerActivator>();
+            var activator = provider.GetRequiredService<IHandlerActivator>();
 
             // Assert
             using (var scope = new RebusTransactionScope())

--- a/Rebus.ServiceProvider/Config/ServiceCollectionExtensions.Bus.cs
+++ b/Rebus.ServiceProvider/Config/ServiceCollectionExtensions.Bus.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Rebus.Activation;
 using Rebus.Bus;
 using Rebus.Config;
 using Rebus.Pipeline;
@@ -48,10 +49,10 @@ It is advised to use one container instance per bus instance, because this way i
             BusLifetimeEvents busLifetimeEvents = null;
 
             // Register the Rebus Bus instance, to be created when it is first requested.
-            services.AddSingleton(provider => new DependencyInjectionHandlerActivator(provider));
+            services.AddSingleton<IHandlerActivator>(provider => new DependencyInjectionHandlerActivator(provider));
             services.AddSingleton(provider =>
             {
-                var activator = provider.GetRequiredService<DependencyInjectionHandlerActivator>();
+                var activator = provider.GetRequiredService<IHandlerActivator>();
 
                 var configurer = Configure.With(activator);
 


### PR DESCRIPTION
Register `DependencyInjectionHandlerActivator` as `IHandlerActivator` allowing it to be patched/mocked.

**Context**
We have a use case where we want to change the way handlers are registered and resolved somewhat, while keeping all other service container registrations as-is. By registering as `IHandlerActivator` we can replace/decorate the implementation of this service type after registering Rebus (with `AddRebus()`)

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
