### PR TITLE
Add async UseRebus overload

### DIFF
--- a/Rebus.ServiceProvider.Tests/Rebus.ServiceProvider.Tests.csproj
+++ b/Rebus.ServiceProvider.Tests/Rebus.ServiceProvider.Tests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Rebus" Version="6.0.0" />

--- a/Rebus.ServiceProvider.Tests/ServiceProviderExtensionsTests.cs
+++ b/Rebus.ServiceProvider.Tests/ServiceProviderExtensionsTests.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using NUnit.Framework;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Tests.Contracts;
+
+namespace Rebus.ServiceProvider.Tests
+{
+    [TestFixture]
+    public class ServiceProviderExtensionsTests : FixtureBase
+    {
+        private Microsoft.Extensions.DependencyInjection.ServiceProvider _serviceProvider;
+        private Mock<IBus> _busMock;
+        private Mock<IBusStarter> _busStarterMock;
+
+        public class TestMessage
+        {
+        }
+
+        protected override void SetUp()
+        {
+            _busMock = new Mock<IBus>
+            {
+                DefaultValue = DefaultValue.Mock
+            };
+
+            _busStarterMock = new Mock<IBusStarter>();
+            _busStarterMock.SetReturnsDefault(_busMock.Object);
+
+            _serviceProvider = new ServiceCollection()
+                .AddRebus(c => c)
+                .Replace(ServiceDescriptor.Singleton(_busStarterMock.Object))
+                .BuildServiceProvider();
+
+            Using(_serviceProvider);
+        }
+
+        [Test]
+        public void UseRebus_StartsBus()
+        {
+            // Act
+            _serviceProvider.UseRebus();
+
+            // Assert
+            _busStarterMock.Verify(m => m.Start(), Times.Once);
+        }
+
+        [Test]
+        public void UseRebus_WithSyncDelegate_ExecutesAndStartsBus()
+        {
+            // Act
+            _serviceProvider.UseRebus(bus =>
+            {
+                Assert.AreEqual(_busMock.Object, bus);
+                bus.Advanced.SyncBus.Subscribe<TestMessage>();
+            });
+
+            // Assert
+            _busStarterMock.Verify(m => m.Start(), Times.Once);
+            _busMock.Verify(m => m.Advanced.SyncBus.Subscribe<TestMessage>(), Times.Once);
+        }
+
+        [Test]
+        public void UseRebus_WithAsyncDelegate_StartsBusAndExecutes()
+        {
+	        // Act
+	        _serviceProvider.UseRebus(async bus =>
+	        {
+		        Assert.AreEqual(_busMock.Object, bus);
+		        await bus.Subscribe<TestMessage>();
+	        });
+
+	        // Assert
+	        _busStarterMock.Verify(m => m.Start(), Times.Once);
+	        _busMock.Verify(m => m.Subscribe<TestMessage>(), Times.Once);
+        }
+    }
+}

--- a/Rebus.ServiceProvider/Internals/AsyncHelpers.cs
+++ b/Rebus.ServiceProvider/Internals/AsyncHelpers.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rebus.ServiceProvider.Internals
+{
+    static class AsyncHelpers
+    {
+        /// <summary>
+        /// Executes a task synchronously on the calling thread by installing a temporary synchronization context that queues continuations
+        ///  </summary>
+        public static void RunSync(Func<Task> task)
+        {
+            var currentContext = SynchronizationContext.Current;
+            var customContext = new CustomSynchronizationContext(task);
+
+            try
+            {
+                SynchronizationContext.SetSynchronizationContext(customContext);
+
+                customContext.Run();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(currentContext);
+            }
+        }
+
+        /// <summary>
+        /// Synchronization context that can be "pumped" in order to have it execute continuations posted back to it
+        /// </summary>
+        class CustomSynchronizationContext : SynchronizationContext
+        {
+            readonly ConcurrentQueue<Tuple<SendOrPostCallback, object>> _items = new ConcurrentQueue<Tuple<SendOrPostCallback, object>>();
+            readonly AutoResetEvent _workItemsWaiting = new AutoResetEvent(false);
+            readonly Func<Task> _task;
+
+            ExceptionDispatchInfo _caughtException;
+
+            bool _done;
+
+            public CustomSynchronizationContext(Func<Task> task)
+            {
+                if (task == null) throw new ArgumentNullException(nameof(task), "Please remember to pass a Task to be executed");
+                _task = task;
+            }
+
+            public override void Post(SendOrPostCallback function, object state)
+            {
+                _items.Enqueue(Tuple.Create(function, state));
+                _workItemsWaiting.Set();
+            }
+
+            /// <summary>
+            /// Enqueues the function to be executed and executes all resulting continuations until it is completely done
+            /// </summary>
+            public void Run()
+            {
+                Post(async _ =>
+                {
+                    try
+                    {
+                        await _task();
+                    }
+                    catch (Exception exception)
+                    {
+                        _caughtException = ExceptionDispatchInfo.Capture(exception);
+                        throw;
+                    }
+                    finally
+                    {
+                        Post(state => _done = true, null);
+                    }
+                }, null);
+
+                while (!_done)
+                {
+                    Tuple<SendOrPostCallback, object> task;
+
+                    if (_items.TryDequeue(out task))
+                    {
+                        task.Item1(task.Item2);
+
+                        if (_caughtException == null) continue;
+
+                        _caughtException.Throw();
+                    }
+                    else
+                    {
+                        _workItemsWaiting.WaitOne();
+                    }
+                }
+            }
+
+            public override void Send(SendOrPostCallback d, object state)
+            {
+                throw new NotSupportedException("Cannot send to same thread");
+            }
+
+            public override SynchronizationContext CreateCopy()
+            {
+                return this;
+            }
+        }
+    }
+}


### PR DESCRIPTION
See #44

Do you prefer `UseRebus` or `UseRebusAsync`? Considering Rebus API pattern is not to use suffix I stuck to that.

Please note this is a breaking change for current integrators if they use `async/void`:
```
app.ApplicationServices.UseRebus(async bus => await bus.Subscribe<SomeMessage>())
```

which after updating has to be prefixed with `await`. Otherwise its a fire and forget task (i.e. potential exceptions are lost).

```
await app.ApplicationServices.UseRebus(async bus => await bus.Subscribe<SomeMessage>())
```


---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
