### PR TITLE
Covariant Polymorphic Dispatch

### DIFF
--- a/Rebus.ServiceProvider.Tests/PolymorphicMessageHandlerActivation.cs
+++ b/Rebus.ServiceProvider.Tests/PolymorphicMessageHandlerActivation.cs
@@ -8,6 +8,7 @@ using Rebus.Activation;
 using Rebus.Handlers;
 using Rebus.Retry.Simple;
 using Rebus.Routing.TypeBased;
+using Rebus.Tests.Contracts;
 using Rebus.Transport;
 using Rebus.Transport.InMem;
 
@@ -17,9 +18,9 @@ namespace Rebus.ServiceProvider.Tests
     ///     Testing the polymorphic message handler activation.
     /// </summary>
     [TestFixture]
-    public class PolymorphicMessageHandlerActivation
+    public class PolymorphicMessageHandlerActivation : FixtureBase
     {
-        private static IHandlerActivator Setup(IHandleMessages testHandler, Type messageHandlerType)
+        private IHandlerActivator Setup(IHandleMessages testHandler, Type messageHandlerType)
         {
             var services = new ServiceCollection();
             
@@ -30,8 +31,7 @@ namespace Rebus.ServiceProvider.Tests
                     .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "Messages"))
                     .Routing(r => r.TypeBased().MapAssemblyOf<Parent>("Messages")));
 
-            var provider = services
-                .BuildServiceProvider()
+            var provider = Using(services.BuildServiceProvider())
                 .UseRebus();
 
             return provider.GetRequiredService<IHandlerActivator>();

--- a/Rebus.ServiceProvider.Tests/PolymorphicMessageHandlerActivation.cs
+++ b/Rebus.ServiceProvider.Tests/PolymorphicMessageHandlerActivation.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Handlers;
+using Rebus.Retry.Simple;
+using Rebus.Routing.TypeBased;
+using Rebus.Transport;
+using Rebus.Transport.InMem;
+
+namespace Rebus.ServiceProvider.Tests
+{
+    /// <summary>
+    ///     Testing the polymorphic message handler activation.
+    /// </summary>
+    [TestFixture]
+    public class PolymorphicMessageHandlerActivation
+    {
+        private static IHandlerActivator Setup(IHandleMessages testHandler, Type messageHandlerType)
+        {
+            var services = new ServiceCollection();
+            
+            services
+                .AddSingleton(messageHandlerType, testHandler)
+                .AddRebus(config => config
+                    .Logging(l => l.None())
+                    .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "Messages"))
+                    .Routing(r => r.TypeBased().MapAssemblyOf<Parent>("Messages")));
+
+            var provider = services
+                .BuildServiceProvider()
+                .UseRebus();
+
+            return provider.GetRequiredService<IHandlerActivator>();
+        }
+        
+        [Test]
+        public async Task Handlers_ShouldHandleSameType()
+        {
+            var activator = Setup(new ChildMessageHandler(), typeof(IHandleMessages<Child>));
+            
+            using (var scope = new RebusTransactionScope())
+            {
+                var handlers = await activator.GetHandlers(new Child(), scope.TransactionContext);
+
+                handlers.Should().HaveCount(1);
+            }
+        }
+        
+        [Test]
+        public async Task Handlers_ShouldHandleSubtype()
+        {
+            var activator = Setup(new ParentMessageHandler(), typeof(IHandleMessages<Parent>));
+            
+            using (var scope = new RebusTransactionScope())
+            {
+                var handlers = await activator.GetHandlers(new Child(), scope.TransactionContext);
+
+                handlers.Should().HaveCount(1);
+            }
+        }
+        
+        [Test]
+        public async Task Handlers_ShouldNotHandleSupertype()
+        {
+            var activator = Setup(new ChildMessageHandler(), typeof(IHandleMessages<Child>));
+            
+            using (var scope = new RebusTransactionScope())
+            {
+                var handlers = await activator.GetHandlers(new Parent(), scope.TransactionContext);
+
+                handlers.Should().HaveCount(0);
+            }
+        }
+
+        [Test]
+        public async Task Handlers_ShouldHandleCovariantSubtype()
+        {
+            var activator = Setup(new CovariantGenericParentMessageHandler(), typeof(IHandleMessages<ICovariantGeneric<Parent>>));
+            
+            using (var scope = new RebusTransactionScope())
+            {
+                var handlers = await activator.GetHandlers(new ConcreteCovariantGeneric<Child>(), scope.TransactionContext);
+
+                handlers.Should().HaveCount(1);
+            }
+        }
+        
+        [Test]
+        public async Task Handlers_ShouldHandleSameCovariantType()
+        {
+            var activator = Setup(new CovariantGenericParentMessageHandler(), typeof(IHandleMessages<ICovariantGeneric<Parent>>));
+            
+            using (var scope = new RebusTransactionScope())
+            {
+                var handlers = await activator.GetHandlers(new ConcreteCovariantGeneric<Parent>(), scope.TransactionContext);
+
+                handlers.Should().HaveCount(1);
+            }
+        }
+        
+        [Test]
+        public async Task Handlers_ShouldHandleMultipleCovariantTypeParameters()
+        {
+            var activator = Setup(new DoubleCovariantMixedMessageHandler(), typeof(IHandleMessages<IDoubleCovariantGeneric<Child, Parent>>));
+            
+            using (var scope = new RebusTransactionScope())
+            {
+                var handlers = await activator.GetHandlers(new ConcreteDoubleCovariantGeneric<Child, Child>(), scope.TransactionContext);
+
+                handlers.Should().HaveCount(1);
+            }
+        }
+        
+        [Test]
+        public async Task Handlers_ShouldHandleMultipleCovariantTypeParametersWithSameType()
+        {
+            var activator = Setup(new DoubleCovariantSameMessageHandler(), typeof(IHandleMessages<IDoubleCovariantGeneric<Child, Child>>));
+            
+            using (var scope = new RebusTransactionScope())
+            {
+                var handlers = await activator.GetHandlers(new ConcreteDoubleCovariantGeneric<Child, Child>(), scope.TransactionContext);
+
+                handlers.Should().HaveCount(1);
+            }
+        }
+        
+        [Test]
+        public async Task Handlers_ShouldNotGetBaseTypesOfRegularTypeParameter()
+        {
+            var activator = Setup(new GenericParentMessageHandler(), typeof(IHandleMessages<IGeneric<Parent>>));
+
+            using (var scope = new RebusTransactionScope())
+            {
+                var handlers = await activator.GetHandlers(new ConcreteGeneric<Child>(), scope.TransactionContext);
+
+                handlers.Should().HaveCount(0);
+            }
+        }
+
+        [Test]
+        public async Task Handlers_ShouldHandleIFailedMessages()
+        {
+            var activator = Setup(new FailedMessageHandler(), typeof(IHandleMessages<IFailed<object>>));
+            
+            using (var scope = new RebusTransactionScope())
+            {
+                var handlers = await activator.GetHandlers(new FailedMessage<Child>(), scope.TransactionContext);
+                handlers.Should().HaveCount(1);
+            }
+        }
+    }
+    
+    public class Parent { }
+    
+    public class Child : Parent { }
+
+    public class ParentMessageHandler : IHandleMessages<Parent>
+    {
+        public Task Handle(Parent message) => Task.CompletedTask;
+    }
+    
+    public class ChildMessageHandler : IHandleMessages<Child>
+    {
+        public Task Handle(Child message) => Task.CompletedTask;
+    }
+    
+    public interface ICovariantGeneric<out T> {}
+    public class ConcreteCovariantGeneric<T> : ICovariantGeneric<T> {}
+    
+    
+    public class CovariantGenericParentMessageHandler : IHandleMessages<ICovariantGeneric<Parent>>
+    {
+        public Task Handle(ICovariantGeneric<Parent> message) => Task.CompletedTask;
+    }
+    
+    public interface IGeneric<T> {}
+    public class ConcreteGeneric<T> : IGeneric<T> {}
+    
+    
+    public class GenericParentMessageHandler : IHandleMessages<IGeneric<Parent>>
+    {
+        public Task Handle(IGeneric<Parent> message) => Task.CompletedTask;
+    }
+    
+    public interface IDoubleCovariantGeneric<out T, out S> {}
+    public class ConcreteDoubleCovariantGeneric<T, S> : IDoubleCovariantGeneric<T, S> {}
+
+    public class DoubleCovariantMixedMessageHandler : IHandleMessages<IDoubleCovariantGeneric<Child, Parent>>
+    {
+        public Task Handle(IDoubleCovariantGeneric<Child, Parent> message) => Task.CompletedTask;
+    }
+    
+    public class DoubleCovariantSameMessageHandler : IHandleMessages<IDoubleCovariantGeneric<Child, Child>>
+    {
+        public Task Handle(IDoubleCovariantGeneric<Child, Child> message) => Task.CompletedTask;
+    }
+
+    public class FailedMessage<T> : IFailed<T>
+    {
+        public T Message { get; }
+        public string ErrorDescription { get; }
+        public Dictionary<string, string> Headers { get; }
+        public IEnumerable<Exception> Exceptions { get; }
+    }
+
+    public class FailedMessageHandler : IHandleMessages<IFailed<object>>
+    {
+        public Task Handle(IFailed<object> message) => Task.CompletedTask;
+    }
+}

--- a/Rebus.ServiceProvider/Internals/EnumerableExtensions.cs
+++ b/Rebus.ServiceProvider/Internals/EnumerableExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Rebus.ServiceProvider.Internals
+{
+    public static class EnumerableExtensions
+    {
+        /// <summary>
+        ///     Returns the Cartesian product of the given collection of collections.
+        /// </summary>
+        public static IEnumerable<IEnumerable<T>> CartesianProduct<T>(this IEnumerable<IEnumerable<T>> sequences)
+        {
+            IEnumerable<IEnumerable<T>> emptyProduct = new[] { Enumerable.Empty<T>() };
+            return sequences.Aggregate(
+                emptyProduct,
+                (accumulator, sequence) =>
+                    from acc in accumulator
+                    from item in sequence
+                    select acc.Concat(new[] { item }));
+        }
+    }
+}

--- a/Rebus.ServiceProvider/ServiceProvider/DependencyInjectionHandlerActivator.cs
+++ b/Rebus.ServiceProvider/ServiceProvider/DependencyInjectionHandlerActivator.cs
@@ -3,12 +3,12 @@ using Rebus.Activation;
 using Rebus.Extensions;
 using Rebus.Handlers;
 using Rebus.Pipeline;
-using Rebus.Retry.Simple;
 using Rebus.Transport;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Rebus.ServiceProvider.Internals;
 
@@ -78,24 +78,69 @@ namespace Rebus.ServiceProvider
                 .Cast<IHandleMessages<TMessage>>()
                 .ToList();
         }
-
+        
         static Type[] FigureOutTypesToResolve(Type messageType)
         {
-            IEnumerable<Type> handledMessageTypes;
-
-            if (messageType.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IFailed<>)))
+            var handledMessageTypes = messageType.GetBaseTypes().ToHashSet();
+            handledMessageTypes.Add(messageType);
+            
+            var compatibleMessageTypes = new HashSet<Type>();
+            foreach (var type in handledMessageTypes)
             {
-                var actualMessageType = messageType.GetGenericArguments()[0];
-                handledMessageTypes = new[] { actualMessageType }.Concat(actualMessageType.GetBaseTypes()).Select(t => typeof(IFailed<>).MakeGenericType(t));
+                compatibleMessageTypes.UnionWith(GetCompatibleMessageHandlerTypes(type));
             }
-            else
-            {
-                handledMessageTypes = new[] { messageType }.Concat(messageType.GetBaseTypes());
-            }
-
+            handledMessageTypes.UnionWith(compatibleMessageTypes);
+            
             return handledMessageTypes
                 .Select(t => typeof(IHandleMessages<>).MakeGenericType(t))
                 .ToArray();
+        }
+
+        /**
+         * Returns all compatible message handler types,
+         * which a message with the given type should be dispatched to.
+         * Covariant interfaces are taken into account.
+         */
+        private static IEnumerable<Type> GetCompatibleMessageHandlerTypes(Type type) 
+        {
+            if (type.IsGenericType)
+            {
+                var genericDefinition = type.GetGenericTypeDefinition();
+                var combinations = genericDefinition.GetGenericArguments()
+                    .Zip(type.GetGenericArguments(), GenericTypePair.Create)
+                    .Select(args => new[] {args.ActualType}.Concat(IsCovariant(args.GenericType) ? args.ActualType.GetBaseTypes() : Enumerable.Empty<Type>()))
+                    .CartesianProduct();
+                var newTypes = combinations.Select(types => genericDefinition.MakeGenericType(types.ToArray()));
+                return newTypes;
+            }
+            
+            return type.GetBaseTypes();
+        }
+        
+        /// <summary>
+        ///     Returns true iff the given type parameter is covariant.
+        /// </summary>
+        private static bool IsCovariant(Type type)
+        {
+            return (type.GenericParameterAttributes & GenericParameterAttributes.Covariant) != 0;
+        }
+
+        /// <summary>
+        ///     Represents a generic type argument and its corresponding actual type.
+        /// </summary>
+        private class GenericTypePair
+        {
+            public Type GenericType { get; private set; }
+            public Type ActualType { get; private set; }
+            
+            public static GenericTypePair Create(Type genericType, Type actualType)
+            {
+                return new()
+                {
+                    GenericType = genericType,
+                    ActualType = actualType
+                };
+            }
         }
     }
 }

--- a/Rebus.ServiceProvider/ServiceProvider/DependencyInjectionHandlerActivator.cs
+++ b/Rebus.ServiceProvider/ServiceProvider/DependencyInjectionHandlerActivator.cs
@@ -121,7 +121,7 @@ namespace Rebus.ServiceProvider
         ///     the given type pair.
         ///     Note that we are conservative in the sense that if any parameter
         ///     constraint exists for the generic type, we don't look for base types,
-        ///     since this might lead these constraints being violated.
+        ///     since this might lead to these constraints being violated.
         /// </summary>
         private static IEnumerable<Type> GetBaseTypes(GenericTypePair typePair)
         {


### PR DESCRIPTION
Added covariant polymorphic dispatch, as per https://github.com/rebus-org/Rebus/issues/934
This should handle the special-case handling of `IFailed` (from https://github.com/rebus-org/Rebus.ServiceProvider/issues/22) more generically and provide additional dispatch capabilities.
From what I could read in https://github.com/rebus-org/Rebus.ServiceProvider/issues/22, this should still be handled.

Note: I have not added contravariant polymorphic dispatch for now. This is potentially more computationally heavy, but it should be quite simple to add it in the future, if someone requests this.
Furthermore, I have chosen to only handle one level of nesting, as I believe the use-cases for more levels of nesting are very rare.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
