### PR TITLE
Minor bugfix for constrained covariant type parameters.

### DIFF
--- a/Rebus.ServiceProvider.Tests/PolymorphicMessageHandlerActivation.cs
+++ b/Rebus.ServiceProvider.Tests/PolymorphicMessageHandlerActivation.cs
@@ -152,6 +152,18 @@ namespace Rebus.ServiceProvider.Tests
                 handlers.Should().HaveCount(1);
             }
         }
+        
+        [Test]
+        public async Task Handlers_ShouldHandleCovariantTypeParametersWithConstraints()
+        {
+            var activator = Setup(new ConstrainedCovariantMessageHandler(), typeof(IHandleMessages<IConstrainedCovariant<Parent>>));
+            
+            using (var scope = new RebusTransactionScope())
+            {
+                var handlers = await activator.GetHandlers(new ConcreteConstrainedCovariant(), scope.TransactionContext);
+                handlers.Should().HaveCount(1);
+            }
+        }
     }
     
     public class Parent { }
@@ -210,5 +222,14 @@ namespace Rebus.ServiceProvider.Tests
     public class FailedMessageHandler : IHandleMessages<IFailed<object>>
     {
         public Task Handle(IFailed<object> message) => Task.CompletedTask;
+    }
+    
+    public interface IConstrainedCovariant<out T> where T : Parent {}
+
+    public class ConcreteConstrainedCovariant : IConstrainedCovariant<Child> {}
+
+    public class ConstrainedCovariantMessageHandler : IHandleMessages<IConstrainedCovariant<Parent>>
+    {
+        public Task Handle(IConstrainedCovariant<Parent> message) => Task.CompletedTask;
     }
 }

--- a/Rebus.ServiceProvider/ServiceProvider/DependencyInjectionHandlerActivator.cs
+++ b/Rebus.ServiceProvider/ServiceProvider/DependencyInjectionHandlerActivator.cs
@@ -141,13 +141,8 @@ namespace Rebus.ServiceProvider
         private static bool SatisfiesParameterConstraints(Type type, IEnumerable<Type> parameterConstraints)
         {
             var implementedTypes = type.GetBaseTypes().ToHashSet();
-            foreach (var constraint in parameterConstraints)
-            {
-                if (!implementedTypes.Contains(constraint))
-                    return false;
-            }
-
-            return true;
+            implementedTypes.Add(type);
+            return parameterConstraints.All(constraint => implementedTypes.Contains(constraint));
         }
         
         /// <summary>
@@ -155,7 +150,7 @@ namespace Rebus.ServiceProvider
         /// </summary>
         private static bool IsCovariant(Type type)
         {
-            return (type.GenericParameterAttributes & GenericParameterAttributes.Covariant) != 0;
+            return type.GenericParameterAttributes.HasFlag(GenericParameterAttributes.Covariant);
         }
 
         /// <summary>


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
