### PR TITLE
Allow injecting Scoped ServiceProvider.

### DIFF
--- a/Rebus.ServiceProvider/Config/ServiceCollectionExtensions.cs
+++ b/Rebus.ServiceProvider/Config/ServiceCollectionExtensions.cs
@@ -48,12 +48,16 @@ public static class ServiceCollectionExtensions
     /// Configures whether this bus should be started automatically (i.e. whether message consumption should begin) when the host starts up (or when StartRebus() is called on the service provider).
     /// Setting this to false should be combined with providing a <paramref name="key"/>, because the bus can then be started by resolving <see cref="IBusRegistry"/> and calling <see cref="IBusRegistry.StartBus"/> on it.
     /// </param>
-    public static IServiceCollection AddRebus(this IServiceCollection services, Func<RebusConfigurer, RebusConfigurer> configure, bool isDefaultBus = true, Func<IBus, Task> onCreated = null, string key = null, bool startAutomatically = true)
+    /// <param name="injectRootServiceProvider">
+    /// Configures whether this the root service provider or a scoped service provider should be injected.
+    /// Setting this to false should be result in a scoped service provider attached to the context, which can be used by Handlers, Event delegates etc.
+    /// </param>
+    public static IServiceCollection AddRebus(this IServiceCollection services, Func<RebusConfigurer, RebusConfigurer> configure, bool isDefaultBus = true, Func<IBus, Task> onCreated = null, string key = null, bool startAutomatically = true, bool injectRootServiceProvider = true)
     {
         if (services == null) throw new ArgumentNullException(nameof(services));
         if (configure == null) throw new ArgumentNullException(nameof(configure));
 
-        return AddRebus(services, (configurer, _) => configure(configurer), isDefaultBus: isDefaultBus, onCreated: onCreated, key: key, startAutomatically: startAutomatically);
+        return AddRebus(services, (configurer, _) => configure(configurer), isDefaultBus: isDefaultBus, onCreated: onCreated, key: key, startAutomatically: startAutomatically, injectRootServiceProvider: injectRootServiceProvider);
     }
 
     /// <summary>
@@ -83,7 +87,11 @@ public static class ServiceCollectionExtensions
     /// Configures whether this bus should be started automatically (i.e. whether message consumption should begin) when the host starts up (or when StartRebus() is called on the service provider).
     /// Setting this to false should be combined with providing a <paramref name="key"/>, because the bus can then be started by resolving <see cref="IBusRegistry"/> and calling <see cref="IBusRegistry.StartBus"/> on it.
     /// </param>
-    public static IServiceCollection AddRebus(this IServiceCollection services, Func<RebusConfigurer, IServiceProvider, RebusConfigurer> configure, bool isDefaultBus = true, Func<IBus, Task> onCreated = null, string key = null, bool startAutomatically = true)
+    /// <param name="injectRootServiceProvider">
+    /// Configures whether this the root service provider or a scoped service provider should be injected.
+    /// Setting this to false should be result in a scoped service provider attached to the context, which can be used by Handlers, Event delegates etc.
+    /// </param>
+    public static IServiceCollection AddRebus(this IServiceCollection services, Func<RebusConfigurer, IServiceProvider, RebusConfigurer> configure, bool isDefaultBus = true, Func<IBus, Task> onCreated = null, string key = null, bool startAutomatically = true, bool injectRootServiceProvider = true)
     {
         if (services == null) throw new ArgumentNullException(nameof(services));
         if (configure == null) throw new ArgumentNullException(nameof(configure));
@@ -100,7 +108,7 @@ public static class ServiceCollectionExtensions
             // NOTE: this was added to support disposal in scenarios where Rebus is hosted with a service provider OUTSIDE of the generic host
         }
 
-        services.AddSingleton<IHostedService>(provider => new RebusBackgroundService(configure, provider, isDefaultBus, onCreated, key, startAutomatically));
+        services.AddSingleton<IHostedService>(provider => new RebusBackgroundService(configure, provider, isDefaultBus, onCreated, key, startAutomatically, injectRootServiceProvider));
 
         if (isDefaultBus)
         {

--- a/Rebus.ServiceProvider/ServiceProvider/ServiceProviderProviderStep.cs
+++ b/Rebus.ServiceProvider/ServiceProvider/ServiceProviderProviderStep.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Rebus.Bus;
 using Rebus.Injection;
 using Rebus.Pipeline;
+using Rebus.Transport;
 
 namespace Rebus.ServiceProvider;
 
@@ -14,15 +16,17 @@ public class ServiceProviderProviderStep : IIncomingStep, IOutgoingStep
 {
     readonly IServiceProvider _serviceProvider;
     readonly Lazy<IBus> _bus;
+    readonly bool _injectRootServiceProvider;
 
     /// <summary>
     /// Creates the step
     /// </summary>
-    public ServiceProviderProviderStep(IServiceProvider serviceProvider, IResolutionContext resolutionContext)
+    public ServiceProviderProviderStep(IServiceProvider serviceProvider, IResolutionContext resolutionContext, bool injectRootServiceProvider = true)
     {
         if (resolutionContext == null) throw new ArgumentNullException(nameof(resolutionContext));
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
         _bus = new(resolutionContext.Get<IBus>);
+        _injectRootServiceProvider = injectRootServiceProvider;
     }
 
     /// <summary>
@@ -30,8 +34,20 @@ public class ServiceProviderProviderStep : IIncomingStep, IOutgoingStep
     /// </summary>
     public async Task Process(IncomingStepContext context, Func<Task> next)
     {
+        if (_injectRootServiceProvider)
+        {
+            context.Save(_serviceProvider);
+        }
+        else
+        {
+            var transactionContext = context.Load<ITransactionContext>();
+
+            var scope = _serviceProvider.CreateScope();
+            transactionContext.OnDisposed(_ => scope.Dispose());
+
+            context.Save(scope);
+        }
         context.Save(_bus.Value);
-        context.Save(_serviceProvider);
         await next();
     }
 
@@ -40,7 +56,21 @@ public class ServiceProviderProviderStep : IIncomingStep, IOutgoingStep
     /// </summary>
     public async Task Process(OutgoingStepContext context, Func<Task> next)
     {
-        context.Save(_serviceProvider);
+        if (_injectRootServiceProvider)
+        {
+            context.Save(_serviceProvider);
+        }
+        else
+        {
+            var transactionContext = context.Load<ITransactionContext>();
+
+            var scope = _serviceProvider.CreateScope();
+            transactionContext.OnDisposed(_ => scope.Dispose());
+
+            context.Save(scope);
+        }
+
+        context.Save(_bus.Value);
         await next();
     }
 }


### PR DESCRIPTION
This should allow for for example the Rebus.Events package to get an actual usable Scope (the same as in the handler). So we can use it to process headers on both incoming and outgoing messages.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
