### PR TITLE
Moved "lazy boy" initialization code to RebusInitializer class

### DIFF
--- a/Rebus.ServiceProvider.Tests/CheckMutlipleBusesAndResolutionByName.cs
+++ b/Rebus.ServiceProvider.Tests/CheckMutlipleBusesAndResolutionByName.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
-using Rebus.Bus;
 using Rebus.Config;
 using Rebus.ServiceProvider.Tests.Internals;
 using Rebus.Transport.InMem;

--- a/Rebus.ServiceProvider.Tests/TestErrorMessages.cs
+++ b/Rebus.ServiceProvider.Tests/TestErrorMessages.cs
@@ -108,9 +108,7 @@ public class TestErrorMessages : FixtureBase
 
         using var provider = services.BuildServiceProvider();
 
-        var exception = Assert.Throws<InvalidOperationException>(() => provider.GetRequiredService<IBus>());
-
-        Console.WriteLine(exception);
+        provider.GetRequiredService<IBus>();
     }
 
     [Test]

--- a/Rebus.ServiceProvider/ServiceProvider/Internals/RebusBackgroundService.cs
+++ b/Rebus.ServiceProvider/ServiceProvider/Internals/RebusBackgroundService.cs
@@ -1,146 +1,21 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Rebus.Bus;
-using Rebus.Config;
-using Rebus.Logging;
-using Rebus.Pipeline;
 
 namespace Rebus.ServiceProvider.Internals;
 
 class RebusBackgroundService : BackgroundService
 {
-    readonly Lazy<Task<(IBus, BusLifetimeEvents)>> _busInitializer;
+    private readonly RebusInitializer _rebusInitializer;
 
-    CancellationToken? _cancellationToken;
-
-    public RebusBackgroundService(Func<RebusConfigurer, IServiceProvider, RebusConfigurer> configure,
-        IServiceProvider serviceProvider, bool isDefaultBus, Func<IBus, Task> onCreated,
-        DefaultBusInstance defaultBusInstance, IHostApplicationLifetime hostApplicationLifetime, string key = null,
-        bool startAutomatically = true)
+    public RebusBackgroundService(RebusInitializer rebusInitializer)
     {
-        // try snatching this
-        _cancellationToken = hostApplicationLifetime?.ApplicationStopping;
-
-        // defer initialization to this lazy boy, because it'll make it possible for whoever calls us first to cause the bus to be initialized
-        _busInitializer = new Lazy<Task<(IBus, BusLifetimeEvents)>>(() => InitializeBus(
-            startAutomatically: startAutomatically,
-            key: key,
-            configure: configure,
-            onCreated: onCreated,
-            serviceProvider: serviceProvider,
-            isDefaultBus: isDefaultBus
-        ));
-
-        if (isDefaultBus)
-        {
-            if (defaultBusInstance == null)
-            {
-                throw new InvalidOperationException(
-                    $"The {nameof(isDefaultBus)} = true paramater said to configure this Rebus instance to be the default bus, but the {nameof(defaultBusInstance)} parameter was NULL!");
-            }
-
-            defaultBusInstance.SetInstanceResolver(_busInitializer);
-        }
+        _rebusInitializer = rebusInitializer;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _cancellationToken = stoppingToken;
-
-        var (bus, _) = await _busInitializer.Value;
-
+        var (bus, _) = await _rebusInitializer._busAndEvents.Value;
         stoppingToken.Register(bus.Dispose);
-    }
-
-    async Task<(IBus, BusLifetimeEvents)> InitializeBus(bool startAutomatically, string key,
-        Func<RebusConfigurer, IServiceProvider, RebusConfigurer> configure,
-        Func<IBus, Task> onCreated, IServiceProvider serviceProvider, bool isDefaultBus)
-    {
-        var stoppingToken = _cancellationToken ?? CancellationToken.None;
-        var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
-        var logger = loggerFactory?.CreateLogger<RebusBackgroundService>();
-
-        BusLifetimeEvents busLifetimeEventsHack = null;
-
-        var rebusConfigurer = Configure
-            .With(new DependencyInjectionHandlerActivator(serviceProvider))
-            .Options(o => o.Decorate(c =>
-            {
-                // snatch events here
-                return busLifetimeEventsHack = c.Get<BusLifetimeEvents>();
-            }))
-            .Options(o => o.Decorate<IPipeline>(context =>
-            {
-                var pipeline = context.Get<IPipeline>();
-                var serviceProviderProviderStep = new ServiceProviderProviderStep(serviceProvider, context);
-                return new PipelineStepConcatenator(pipeline)
-                    .OnReceive(serviceProviderProviderStep, PipelineAbsolutePosition.Front);
-            }));
-
-        var configurer = configure(rebusConfigurer, serviceProvider);
-
-        var starter = configurer
-            .Logging(l =>
-            {
-                if (loggerFactory == null) return;
-
-                try
-                {
-                    // wild hack: Reflect into Injectionist to see, if a logger factory has already been registered
-                    if (l.ReflectWhetherItHasRegistration<IRebusLoggerFactory>())
-                    {
-                        return;
-                    }
-
-                    l.Use(new MicrosoftExtensionsLoggingLoggerFactory(loggerFactory));
-                }
-                catch (InvalidOperationException)
-                {
-                    // ignore this exception, because it'll simply mean that a logger factory has already been configured,
-                    // and so we should ignore that... 
-                }
-            })
-            .Create();
-
-        var bus = starter.Bus;
-
-        logger?.LogInformation("Successfully created bus instance {busInstance} (isDefaultBus: {flag})", bus, isDefaultBus);
-
-        // stopping the bus here will ensure that we've finished executing all message handlers when the container is disposed
-        stoppingToken.Register(() =>
-        {
-            logger?.LogDebug("Stopping token signaled - disposing bus instance {busInstance}", bus);
-            bus.Dispose();
-            logger?.LogInformation("Bus instance {busInstance} successfully disposed", bus);
-        });
-
-        if (key != null)
-        {
-            var registry = serviceProvider.GetRequiredService<ServiceProviderBusRegistry>();
-            registry.AddBus(bus, starter, key);
-            logger?.LogDebug("Bus instance {busInstance} was registered in IBusRegistry with key {key}", bus, key);
-        }
-
-        if (onCreated != null)
-        {
-            logger?.LogDebug("Invoking onCreated callback on bus instance {busInstance}", bus);
-            await onCreated(bus);
-        }
-
-        if (startAutomatically)
-        {
-            logger?.LogDebug("Starting bus instance {busInstance}", bus);
-            starter.Start();
-        }
-        else
-        {
-            logger?.LogDebug("NOT starting bus instance {busInstance}, because it has been configured with startAutomatically:false", bus);
-        }
-
-        return (bus, busLifetimeEventsHack);
     }
 }

--- a/Rebus.ServiceProvider/ServiceProvider/Internals/RebusInitializer.cs
+++ b/Rebus.ServiceProvider/ServiceProvider/Internals/RebusInitializer.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Logging;
+using Rebus.Pipeline;
+
+namespace Rebus.ServiceProvider.Internals;
+
+class RebusInitializer
+{
+    public readonly Lazy<Task<(IBus, BusLifetimeEvents)>> _busAndEvents;
+    
+    private readonly bool _startAutomatically;
+    private readonly string _key;
+    private readonly Func<RebusConfigurer, IServiceProvider, RebusConfigurer> _configure;
+    private readonly Func<IBus, Task> _onCreated;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly bool _isDefaultBus;
+    private readonly CancellationToken? _cancellationToken;
+
+    public RebusInitializer(
+        bool startAutomatically,
+        string key,
+        Func<RebusConfigurer, IServiceProvider, RebusConfigurer> configure,
+        Func<IBus, Task> onCreated,
+        IServiceProvider serviceProvider,
+        bool isDefaultBus,
+        IHostApplicationLifetime lifetime)
+    {
+        _startAutomatically = startAutomatically;
+        _key = key;
+        _configure = configure;
+        _onCreated = onCreated;
+        _serviceProvider = serviceProvider;
+        _isDefaultBus = isDefaultBus;
+        _cancellationToken = lifetime?.ApplicationStopping;
+
+        _busAndEvents = GetLazyInitializer();
+    }
+    
+    public Lazy<Task<(IBus, BusLifetimeEvents)>> GetLazyInitializer()
+    {
+        return new Lazy<Task<(IBus, BusLifetimeEvents)>>(async () =>
+        {
+            var stoppingToken = _cancellationToken ?? CancellationToken.None;
+            var loggerFactory = _serviceProvider.GetService<ILoggerFactory>();
+            var logger = loggerFactory?.CreateLogger<RebusBackgroundService>();
+
+            BusLifetimeEvents busLifetimeEventsHack = null;
+
+            var rebusConfigurer = Configure
+                .With(new DependencyInjectionHandlerActivator(_serviceProvider))
+                .Options(o => o.Decorate(c =>
+                {
+                    // snatch events here
+                    return busLifetimeEventsHack = c.Get<BusLifetimeEvents>();
+                }))
+                .Options(o => o.Decorate<IPipeline>(context =>
+                {
+                    var pipeline = context.Get<IPipeline>();
+                    var serviceProviderProviderStep = new ServiceProviderProviderStep(_serviceProvider, context);
+                    return new PipelineStepConcatenator(pipeline)
+                        .OnReceive(serviceProviderProviderStep, PipelineAbsolutePosition.Front);
+                }));
+
+            var configurer = _configure(rebusConfigurer, _serviceProvider);
+
+            var starter = configurer
+                .Logging(l =>
+                {
+                    if (loggerFactory == null) return;
+
+                    try
+                    {
+                        // wild hack: Reflect into Injectionist to see, if a logger factory has already been registered
+                        if (l.ReflectWhetherItHasRegistration<IRebusLoggerFactory>())
+                        {
+                            return;
+                        }
+
+                        l.Use(new MicrosoftExtensionsLoggingLoggerFactory(loggerFactory));
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        // ignore this exception, because it'll simply mean that a logger factory has already been configured,
+                        // and so we should ignore that... 
+                    }
+                })
+                .Create();
+
+            var bus = starter.Bus;
+
+            logger?.LogInformation("Successfully created bus instance {busInstance} (isDefaultBus: {flag})", bus,
+                _isDefaultBus);
+
+            // stopping the bus here will ensure that we've finished executing all message handlers when the container is disposed
+            stoppingToken.Register(() =>
+            {
+                logger?.LogDebug("Stopping token signaled - disposing bus instance {busInstance}", bus);
+                bus.Dispose();
+                logger?.LogInformation("Bus instance {busInstance} successfully disposed", bus);
+            });
+
+            if (_key != null)
+            {
+                var registry = _serviceProvider.GetRequiredService<ServiceProviderBusRegistry>();
+                registry.AddBus(bus, starter, _key);
+                logger?.LogDebug("Bus instance {busInstance} was registered in IBusRegistry with key {key}", bus, _key);
+            }
+
+            if (_onCreated != null)
+            {
+                logger?.LogDebug("Invoking onCreated callback on bus instance {busInstance}", bus);
+                await _onCreated(bus);
+            }
+
+            if (_startAutomatically)
+            {
+                logger?.LogDebug("Starting bus instance {busInstance}", bus);
+                starter.Start();
+            }
+            else
+            {
+                logger?.LogDebug(
+                    "NOT starting bus instance {busInstance}, because it has been configured with startAutomatically:false",
+                    bus);
+            }
+
+            return (bus, busLifetimeEventsHack);
+        });
+    }
+}


### PR DESCRIPTION
Moved "lazy boy" initialization code to RebusInitializer class, so it can be called and bus started when IBus instance is first resolved. This way the bus instance can be injected into another IHostedService or used in Startup's Configure method.

Closes #61 

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
