### PR TITLE
Allow types to be forwarded from host container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ _ReSharper.*
 _NCrunch_*
 *.user
 *.backup
+.idea/*
 
 # MS Guideline
 **/packages/*

--- a/README.md
+++ b/README.md
@@ -240,9 +240,9 @@ builder.Host.AddRebusService(
 * `Microsoft.Extensions.Hosting.IHostApplicationLifetime`
 * `Microsoft.Extensions.Logging.ILoggerFactory`
 
-to the host's container, which essentially makes these things transparently available to the separate Rebus service.
+to the host's container, which essentially makes these things transparently available, as singletons, to the separate Rebus service.
 
-If you forward requests for other types to the host's container you can add to the list of forwarded types like this:
+If you forward requests for other singletons to the host's container you can add to the list of forwarded singleton types:
 
 ```csharp
 builder.Host.AddRebusService(

--- a/README.md
+++ b/README.md
@@ -242,6 +242,17 @@ builder.Host.AddRebusService(
 
 to the host's container, which essentially makes these things transparently available to the separate Rebus service.
 
+If you forward requests for other types to the host's container you can add to the list of forwarded types like this:
+
+```csharp
+builder.Host.AddRebusService(
+    services => services.AddRebus(...),
+    typeof(IMyDateTimeProvider),
+    typeof(IMyImportantService),
+    ... etc
+);
+```
+
 
 ### Primary bus instance?
 

--- a/Rebus.ServiceProvider/Config/HostBuilderExtensions.cs
+++ b/Rebus.ServiceProvider/Config/HostBuilderExtensions.cs
@@ -41,9 +41,9 @@ public static class HostBuilderExtensions
     /// <see cref="ServiceCollectionExtensions.AddRebus(IServiceCollection,Func{RebusConfigurer,RebusConfigurer},bool,Func{IBus,Task})"/>
     /// or <see cref="ServiceCollectionExtensions.AddRebus(IServiceCollection,Func{RebusConfigurer,IServiceProvider,RebusConfigurer},bool,Func{IBus,Task})"/>
     /// </param>
-    /// <param name="forwardedServiceTypes">Types available from the host's service provider which should be transiently forwarded into the hosted
+    /// <param name="forwardedSingletonTypes">Types available from the host's service provider which should be transiently forwarded into the hosted
     /// service's container</param>
-    public static IHostBuilder AddRebusService(this IHostBuilder builder, Action<IServiceCollection> configureServices, params Type[] forwardedServiceTypes)
+    public static IHostBuilder AddRebusService(this IHostBuilder builder, Action<IServiceCollection> configureServices, params Type[] forwardedSingletonTypes)
     {
         return builder.ConfigureServices((_, hostServices) =>
         {
@@ -52,9 +52,9 @@ public static class HostBuilderExtensions
                 void ConfigureServices(IServiceCollection services)
                 {
                     // add forwards to host service provider
-                    foreach (Type forwardedType in forwardedServiceTypes)
+                    foreach (Type forwardedType in forwardedSingletonTypes)
                     {
-                        services.AddTransientForward(forwardedType, provider);
+                        services.AddSingletonForward(forwardedType, provider);
                     }
 
                     // configure user's services
@@ -78,8 +78,8 @@ public static class HostBuilderExtensions
         });
     }
 
-    private static void AddTransientForward(this IServiceCollection services, Type forwardedType, IServiceProvider appProvider)
+    private static void AddSingletonForward(this IServiceCollection services, Type forwardedType, IServiceProvider appProvider)
     {
-        services.AddTransient(forwardedType, hostedProvider => appProvider.GetService(forwardedType));
+        services.AddSingleton(forwardedType, hostedProvider => appProvider.GetRequiredService(forwardedType));
     }
 }


### PR DESCRIPTION
Currently AddRebusService hard codes IHostApplicationLifetime and ILoggerFactory to be forwarded. This PR generalises this to allow us to pass in a (short) list of additional types to be forwarded. It is recommended that only Singleton and Transient types are forwarded using this mechanism.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
