### PR TITLE
Make ServiceProvider available in outgoing steps again

### DIFF
--- a/Rebus.ServiceProvider/ServiceProvider/Internals/RebusInitializer.cs
+++ b/Rebus.ServiceProvider/ServiceProvider/Internals/RebusInitializer.cs
@@ -65,7 +65,8 @@ class RebusInitializer
                     var pipeline = context.Get<IPipeline>();
                     var serviceProviderProviderStep = new ServiceProviderProviderStep(_serviceProvider, context);
                     return new PipelineStepConcatenator(pipeline)
-                        .OnReceive(serviceProviderProviderStep, PipelineAbsolutePosition.Front);
+                        .OnReceive(serviceProviderProviderStep, PipelineAbsolutePosition.Front)
+                        .OnSend(serviceProviderProviderStep, PipelineAbsolutePosition.Front);
                 }));
 
             var configurer = _configure(rebusConfigurer, _serviceProvider);


### PR DESCRIPTION
Hello! When upgrading to version 8 I noticed the service provider was no longer available in outgoing steps. In version 7 and earlier it was available in both incoming and outgoing steps. It's not that hard to work around, but unless there was a reason for changing it maybe the old behavior could just be restored like this?

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
