### PR TITLE
Forward all singletons to Rebus service

### DIFF
--- a/Rebus.ServiceProvider/Config/HostBuilderExtensions.cs
+++ b/Rebus.ServiceProvider/Config/HostBuilderExtensions.cs
@@ -135,6 +135,9 @@ public static class HostBuilderExtensions
         if (forwardedType == null) throw new ArgumentNullException(nameof(forwardedType));
         if (hostProvider == null) throw new ArgumentNullException(nameof(hostProvider));
 
-        services.AddSingleton(forwardedType, _ => hostProvider.GetRequiredService(forwardedType));
+        foreach (var service in hostProvider.GetServices(forwardedType))
+        {
+            services.AddSingleton(forwardedType, service);
+        }
     }
 }


### PR DESCRIPTION
This change fixes an edge case when supplying `forwardedSingletonTypes` to `HostBuilderExtensions.AddRebusService()`. The forwarded type may be an interface with multiple implementations registered, in which case all of the implementations should be forwarded.

There is a slight change in behavior; where `hostProvider.GetRequiredService(forwardedType)` would previously throw if the type was not registered, `hostProvider.GetServices(forwardedType)` will simply return an empty collection.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
