### PR TITLE
Update Rebus.ServiceProvider.csproj updated reference for Microsoft.E…

### DIFF
--- a/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
+++ b/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
@@ -22,8 +22,8 @@
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard20'">
 		<PackageReference Include="Rebus" Version="[8.0.0-alpha01,)" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3, 6)" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[3, 6)" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3, 7)" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[3, 7)" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net60'">
 		<PackageReference Include="Rebus" Version="[8.0.0-alpha01,)" />


### PR DESCRIPTION
…xtensions.DependencyInjection

Microsoft.Extensions.DependencyInjection is now released in version 7 which does support netstandard 2.0&2.1

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
