### PR TITLE
Implement auto-registration methods that allow filtering by namespace.

### DIFF
--- a/Rebus.ServiceProvider.Tests/AutoRegisterHandlersByNamespace.cs
+++ b/Rebus.ServiceProvider.Tests/AutoRegisterHandlersByNamespace.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Rebus.Config;
+using Rebus.Handlers;
+using Rebus.ServiceProvider.Tests.NamespaceTest1;
+
+namespace Rebus.ServiceProvider.Tests
+{
+    [TestFixture]
+    public class AutoRegisterHandlersByNamespace
+    {
+        [Test]
+        public void Registers_handlers_in_specific_namespace()
+        {
+            var services = new ServiceCollection();
+            services.AutoRegisterHandlersFromAssemblyNamespaceOf<Namespace1TestHandler1>();
+
+            var provider = services.BuildServiceProvider();
+            var handlers = provider.GetServices<IHandleMessages<string>>()
+                .ToList();
+
+            // Should auto register the 2 handlers in Namespace1
+            // and not register the 1 that's in Namespace2.
+            Assert.AreEqual(2, handlers.Count);
+            Assert.IsInstanceOf<Namespace1TestHandler1>(handlers[0]);
+            Assert.IsInstanceOf<Namespace1TestHandler2>(handlers[1]);
+        }
+    }
+}
+
+namespace Rebus.ServiceProvider.Tests.NamespaceTest1
+{
+    public class Namespace1TestHandler1 : IHandleMessages<string>
+    {
+        public Task Handle(string message)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+
+    public class Namespace1TestHandler2 : IHandleMessages<string>
+    {
+        public Task Handle(string message)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}
+
+namespace Rebus.ServiceProvider.Tests.NamespaceTest2
+{
+    public class Namespace2TestHandler1 : IHandleMessages<string>
+    {
+        public Task Handle(string message)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
The Rebus.Autofac package has methods that allow auto-registration for handlers filtered by namespace. This PR brings equivalent functionality to Rebus.ServiceProvider by adding 2 new methods:

```csharp
services.AutoRegisterHandlersFromAssemblyNamespaceOf<MyHandler>();
services.AutoRegisterHandlersFromAssemblyNamespaceOf(typeof(MyHandler));
```

This is useful as you can use namespaces to scope handlers for a specific queue.

Please let me know if you'd like me to amend anything. 

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
