### PR TITLE
fix net8.0, “This service descriptor is keyed. Your service provider …

### DIFF
--- a/Rebus.ServiceProvider/Config/ServiceCollectionExtensions.cs
+++ b/Rebus.ServiceProvider/Config/ServiceCollectionExtensions.cs
@@ -121,7 +121,11 @@ public static class ServiceCollectionExtensions
             services.AddSingleton<IHostedService>(p => new RebusBackgroundService(new RebusInitializer(startAutomatically, key, configure, onCreated, p, isDefaultBus, p.GetService<IHostApplicationLifetime>())));
         }
 
+#if NET8_0_OR_GREATER
+        if (!services.Any(s => (s.IsKeyedService ? s.KeyedImplementationType : s.ImplementationType) == typeof(RebusResolver)))
+#else
         if (!services.Any(s => s.ImplementationType == typeof(RebusResolver)))
+#endif
         {
             services.AddSingleton(new RebusResolver());
             services.AddSingleton(new ServiceProviderBusRegistry());
@@ -274,7 +278,7 @@ public static class ServiceCollectionExtensions
         {
             typesToAutoRegister = typesToAutoRegister.Where(x => predicate(x.Type));
         }
-        
+
         foreach (var type in typesToAutoRegister)
         {
             RegisterType(services, type.Type);

--- a/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
+++ b/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard20;netstandard21</TargetFrameworks>
+		<TargetFrameworks>netstandard20;netstandard21;net8.0</TargetFrameworks>
 		<LangVersion>11</LangVersion>
 		<Authors>mookid8000</Authors>
 		<PackageProjectUrl>https://rebus.fm/what-is-rebus/</PackageProjectUrl>
@@ -20,14 +20,19 @@
 			<PackagePath></PackagePath>
 		</None>
 		<None Include="..\README.md">
-		  <Pack>True</Pack>
-		  <PackagePath>\</PackagePath>
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
 		</None>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Rebus" Version="[8.0.1,)" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[6, 9)" />
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[6, 9)" />
-		<PackageReference Include="microsoft.extensions.logging.abstractions" Version="[6, 9)" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[6, 9)" />
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[6, 9)" />
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[8, 9)" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
fix #86 

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
