### PR TITLE
Add support for .NET 9

### DIFF
--- a/Rebus.ServiceProvider.Tests/Rebus.ServiceProvider.Tests.csproj
+++ b/Rebus.ServiceProvider.Tests/Rebus.ServiceProvider.Tests.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net48;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
 		<LangVersion>11</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Rebus.ServiceProvider\Rebus.ServiceProvider.csproj" />
-		<PackageReference Include="FluentAssertions" Version="6.12.0" />
-		<PackageReference Include="microsoft.extensions.logging" Version="6.0.0" />
-		<PackageReference Include="microsoft.extensions.logging.console" Version="6.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="FluentAssertions" Version="6.12.2" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
 		<PackageReference Include="Rebus.Tests.Contracts" Version="8.0.1" />
 	</ItemGroup>
 </Project>

--- a/Rebus.ServiceProvider.Tests/Rebus.ServiceProvider.Tests.csproj
+++ b/Rebus.ServiceProvider.Tests/Rebus.ServiceProvider.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<LangVersion>11</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>

--- a/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
+++ b/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
@@ -25,14 +25,14 @@
 		</None>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Rebus" Version="[8.0.1,)" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[6, 9)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[6, 9)" />
+		<PackageReference Include="Rebus" Version="[8.0.1, )" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[6, 10)" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[6, 10)" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[6, 9)" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[6, 10)" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[8, 9)" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[8, 10)" />
 	</ItemGroup>
 </Project>

--- a/Sample.ConsoleApp/Sample.ConsoleApp.csproj
+++ b/Sample.ConsoleApp/Sample.ConsoleApp.csproj
@@ -2,12 +2,12 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Rebus" Version="8.0.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+		<PackageReference Include="Rebus" Version="8.6.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Sample.MvcWebApp/Sample.MvcWebApp.csproj
+++ b/Sample.MvcWebApp/Sample.MvcWebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/Sample.WebApp/Sample.WebApp.csproj
+++ b/Sample.WebApp/Sample.WebApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -12,7 +12,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Sample.WorkerService/Sample.WorkerService.csproj
+++ b/Sample.WorkerService/Sample.WorkerService.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ cache:
   - '%LocalAppData%\NuGet\Cache'
 
 before_build:
+  - choco install dotnet-sdk --version 9.0.100 # Manually install .NET 9 SDK (until it's available in the image: https://github.com/appveyor/ci/issues/3936)
   - appveyor-retry dotnet restore -v Minimal
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ cache:
   - '%LocalAppData%\NuGet\Cache'
 
 before_build:
-  - choco install dotnet-sdk --version 9.0.100 # Manually install .NET 9 SDK (until it's available in the image: https://github.com/appveyor/ci/issues/3936)
   - appveyor-retry dotnet restore -v Minimal
 
 build_script:


### PR DESCRIPTION
This extends the upper dependency version limits to allow .NET 9 packages, fixing https://github.com/rebus-org/Rebus.ServiceProvider/issues/95.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
