### PR TITLE
Add keyed registration and resolvation of handlers

### DIFF
--- a/Rebus.ServiceProvider.Tests/Examples/KeyedServices.cs
+++ b/Rebus.ServiceProvider.Tests/Examples/KeyedServices.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Rebus.Config;
+using Rebus.Handlers;
+using Rebus.Tests.Contracts;
+using Rebus.Transport.InMem;
+#pragma warning disable CS1998
+
+namespace Rebus.ServiceProvider.Tests.Examples;
+
+#if NET8_0_OR_GREATER
+[TestFixture]
+[Description("Demonstrates how a service key can be used to resolve Rebus handlers")]
+public class KeyedServices : FixtureBase
+{
+    [Test]
+    public async Task ItWorks()
+    {
+        var services = new ServiceCollection();
+
+        var bus1Key = "bus1";
+        var bus2Key = "bus2";
+
+        var log = new List<string>();
+
+        services.AddRebusHandler<Handler1>(bus1Key, (serviceProvider, serviceKey) => new((string)serviceKey, log));
+        services.AddRebusHandler<Handler2>(bus2Key, (serviceProvider, serviceKey) => new((string)serviceKey, log));
+
+        services.AddRebus(
+            configure => configure.Transport(t => t.UseInMemoryTransport(new InMemNetwork(), $"queue-{Guid.NewGuid():N}")),
+            isDefaultBus: true, 
+            key: bus1Key,
+            serviceKey: bus1Key);
+
+        services.AddRebus(
+            configure => configure.Transport(t => t.UseInMemoryTransport(new InMemNetwork(), $"queue-{Guid.NewGuid():N}")),
+            isDefaultBus: false,
+            key: bus2Key,
+            serviceKey: bus2Key);
+
+        await using var provider = services.BuildServiceProvider();
+        provider.StartRebus();
+
+        var bus1 = provider.GetRequiredService<IBusRegistry>().GetBus(bus1Key);
+        var bus2 = provider.GetRequiredService<IBusRegistry>().GetBus(bus2Key);
+
+        await bus1.SendLocal("Hej!");
+        await bus2.SendLocal("Hej!");
+
+        await Task.Delay(TimeSpan.FromSeconds(3));
+
+        CollectionAssert.AreEquivalent(new[] { bus1Key, bus2Key }, log);
+    }
+
+    class Handler1(string serviceKey, List<string> log) : IHandleMessages<string>
+    {
+        public async Task Handle(string _) => log.Add(serviceKey);
+    }
+
+    class Handler2(string serviceKey, List<string> log) : IHandleMessages<string>
+    {
+        public async Task Handle(string _) => log.Add(serviceKey);
+    }
+}
+#endif

--- a/Rebus.ServiceProvider.Tests/Examples/KeyedServices.cs
+++ b/Rebus.ServiceProvider.Tests/Examples/KeyedServices.cs
@@ -52,7 +52,7 @@ public class KeyedServices : FixtureBase
 
         await Task.Delay(TimeSpan.FromSeconds(3));
 
-        CollectionAssert.AreEquivalent(new[] { bus1Key, bus2Key }, log);
+        Assert.That(log, Is.EquivalentTo(new[] { bus1Key, bus2Key }));
     }
 
     class Handler1(string serviceKey, List<string> log) : IHandleMessages<string>

--- a/Rebus.ServiceProvider.Tests/Rebus.ServiceProvider.Tests.csproj
+++ b/Rebus.ServiceProvider.Tests/Rebus.ServiceProvider.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net48;net8.0</TargetFrameworks>
-		<LangVersion>11</LangVersion>
+		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Rebus.ServiceProvider\Rebus.ServiceProvider.csproj" />


### PR DESCRIPTION
The proposal of changes for basic keyed services support. 

What bothers me is that it somewhat overlaps with `IBusRegistry` but since keyed services are supported only if .NET >= 8 there is no way out of this I guess. 

Feel free to close this PR if you think it doesn't make sense at all :)

What it does for me, is that it allows to use solution 1) from rebus-org/Rebus#1194 with Rebus.ServiceProvider. But it was just an experiment, I don't use it.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
