### PR TITLE
upgrade to .net 10 and allow newer dependencies on Microsoft.Extensions

### DIFF
--- a/Rebus.ServiceProvider.Tests/Rebus.ServiceProvider.Tests.csproj
+++ b/Rebus.ServiceProvider.Tests/Rebus.ServiceProvider.Tests.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net10.0</TargetFrameworks>
 		<LangVersion>13</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Rebus.ServiceProvider\Rebus.ServiceProvider.csproj" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
 		<PackageReference Include="nunit" Version="4.4.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />

--- a/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
+++ b/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard20;netstandard21;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard20;netstandard21;net8.0;net10.0</TargetFrameworks>
 		<LangVersion>13</LangVersion>
 		<Authors>mookid8000</Authors>
 		<PackageProjectUrl>https://rebus.fm/what-is-rebus/</PackageProjectUrl>
@@ -26,13 +26,16 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Rebus" Version="8.9.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[6, 10)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[6, 10)" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[6, 11)" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[6, 11)" />
 	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[6, 10)" />
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard20' OR '$(TargetFramework)' == 'netstandard21' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[6, 11)" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[8, 10)" />
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[8, 11)" />
 	</ItemGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,14 @@ cache:
   - packages -> **\packages.config
   - '%LocalAppData%\NuGet\Cache'
 
+install: 
+- ps: |
+    Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -UseBasicParsing -OutFile "$env:temp\dotnet-install.ps1"
+    & $env:temp\dotnet-install.ps1 -Architecture x64 -Version '10.0.100' -InstallDir "$env:ProgramFiles\dotnet"  # until it is available in the build agent image (https://github.com/appveyor/ci/issues/3984)
+
 before_build:
   - appveyor-retry dotnet restore -v Minimal
+  - cmd: dotnet --version ## Verify that the correct .NET SDK version is being used
 
 build_script:
   - dotnet build Rebus.ServiceProvider -c Release --no-restore


### PR DESCRIPTION
I replaced the != net8.0 by explicit netstandard20 & netstandard21 so that there is no confusion on what libraries to depend on for the Microsoft.Extensions.DependencyInjection.

fixes #101 

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
