### PR TITLE
Update Microsoft.Extensions.DependencyInjection version range (net8.0)

### DIFF
--- a/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
+++ b/Rebus.ServiceProvider/Rebus.ServiceProvider.csproj
@@ -33,7 +33,7 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[6, 11)" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[8, 10)" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[8, 11)" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[8, 11)" />


### PR DESCRIPTION
fixed wrong .net 8.0 dependency range

from: Microsoft.Extensions.DependencyInjection (>= 8.0.0 && < 10.0.0)
to: Microsoft.Extensions.DependencyInjection (>= 8.0.0 && < 11.0.0)

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
